### PR TITLE
Fix: Copying Assets

### DIFF
--- a/src/core/client/api.ts
+++ b/src/core/client/api.ts
@@ -296,6 +296,7 @@ export interface Service {
   ast(id: string, body: AstCommand[]): Promise<Entity<any>>;
   debug(input: DebugRequest): Promise<DebugResponse>;
   getSite(): Promise<Site>
+  copy(id: string, name: string): Promise<Site>
 }
 export interface Store {
   fetch<T>(path: string, init?: RequestInit): Promise<T>;

--- a/src/core/client/index.ts
+++ b/src/core/client/index.ts
@@ -82,6 +82,9 @@ namespace HdesClient {
     debug(debug: HdesClient.DebugRequest): Promise<HdesClient.DebugResponse> {
       return this._store.fetch("/debugs", { method: "POST", body: JSON.stringify(debug) });
     }
+    copy(id: string, name: string): Promise<HdesClient.Site> {
+      return this._store.fetch("/copyas", { method: "POST", body: JSON.stringify({ id, name }) });
+    }
   }
 }
 

--- a/src/core/explorer/flow/FlowOptions.tsx
+++ b/src/core/explorer/flow/FlowOptions.tsx
@@ -144,17 +144,18 @@ const FlowOptions: React.FC<{ flow: Client.Entity<Client.AstFlow> }> = ({ flow }
         labelText={<FormattedMessage id="flows.copyas.title" />}>
       </Burger.TreeItemOption>
 
-      {dialogOpen === 'FlowCopy' ? <Burger.Dialog open={true}
-      onClose={handleDialogClose}
-      children={editor}
-      backgroundColor="uiElements.main"
-      title='flows.composer.copyTitle'
-      submit={{
-        title: "buttons.copy",
-        disabled: apply,
-        onClick: () => handleCopy()
-      }}
-    /> : null}
+      {dialogOpen === 'FlowCopy' ? 
+      <Burger.Dialog open={true}
+        onClose={handleDialogClose}
+        children={editor}
+        backgroundColor="uiElements.main"
+        title='flows.composer.copyTitle'
+        submit={{
+          title: "buttons.copy",
+          disabled: apply,
+          onClick: () => handleCopy()
+        }}
+      /> : null}
     </>
   );
 }

--- a/src/core/explorer/flow/FlowOptions.tsx
+++ b/src/core/explorer/flow/FlowOptions.tsx
@@ -10,6 +10,7 @@ import Burger from '@the-wrench-io/react-burger';
 
 import { Composer, Client } from '../../context';
 import {ErrorView} from '../../styles';
+import { FlowComposer } from '../../flow';
 
 
 const FlowDelete: React.FC<{ flowId: Client.FlowId, onClose: () => void }> = ({ flowId, onClose }) => {
@@ -64,10 +65,52 @@ const FlowDelete: React.FC<{ flowId: Client.FlowId, onClose: () => void }> = ({ 
 
 const FlowOptions: React.FC<{ flow: Client.Entity<Client.AstFlow> }> = ({ flow }) => {
 
-  const [dialogOpen, setDialogOpen] = React.useState<undefined | 'FlowDelete'>(undefined);
+  const [dialogOpen, setDialogOpen] = React.useState<undefined | 'FlowDelete' | 'FlowCopy'>(undefined);
   const nav = Composer.useNav();
   const {handleDebugInit} = Composer.useDebug();
   const handleDialogClose = () => setDialogOpen(undefined);
+  const { service, actions } = Composer.useComposer();
+  const { enqueueSnackbar } = useSnackbar();
+  const [name, setName] = React.useState(flow.ast?.name + "_copy");
+  const [apply, setApply] = React.useState(false);
+  const [errors, setErrors] = React.useState<Client.StoreError>();
+
+  const handleCopy = () => {
+    setErrors(undefined);
+    setApply(true);
+
+    service.copy(flow.id, name)
+      .then(data => {
+        enqueueSnackbar(<FormattedMessage id="flows.composer.copiedMessage" values={{ name: flow.ast?.name, newName: name }} />);
+        actions.handleLoadSite(data).then(() => {
+          const [article] = Object.values(data.flows).filter(d => d.ast?.name === name);
+          nav.handleInTab({ article })
+        });
+        handleDialogClose();
+      }).catch((error: Client.StoreError) => {
+        setErrors(error);
+      });
+  }
+
+
+  let editor = (<></>);
+  if (errors) {
+    editor = (<Box>
+      <Typography variant="h4">
+        <FormattedMessage id="flows.composer.errorsTitle" />
+      </Typography>
+      <ErrorView error={errors} />
+    </Box>)
+  } else {
+    editor = (<Typography variant="h4">
+      <Burger.TextField
+        label='flows.composer.assetName'
+        value={name}
+        onChange={setName}
+        onEnter={() => handleCopy()} />
+    </Typography>)
+  }
+  
 
   return (
     <>
@@ -97,9 +140,21 @@ const FlowOptions: React.FC<{ flow: Client.Entity<Client.AstFlow> }> = ({ flow }
       <Burger.TreeItemOption nodeId={flow.id + 'copyas-nested'}
         color='article'
         icon={EditIcon}
-        onClick={() => nav.handleInTab({ article: flow })}
+        onClick={() => setDialogOpen('FlowCopy')}
         labelText={<FormattedMessage id="flows.copyas.title" />}>
       </Burger.TreeItemOption>
+
+      {dialogOpen === 'FlowCopy' ? <Burger.Dialog open={true}
+      onClose={handleDialogClose}
+      children={editor}
+      backgroundColor="uiElements.main"
+      title='flows.composer.copyTitle'
+      submit={{
+        title: "buttons.copy",
+        disabled: apply,
+        onClick: () => handleCopy()
+      }}
+    /> : null}
     </>
   );
 }

--- a/src/core/intl/en.ts
+++ b/src/core/intl/en.ts
@@ -3,6 +3,7 @@ const en = {
   'buttons.apply': "Apply",
   'buttons.delete': "Delete",
   'button.cancel': "Cancel",
+  'buttons.copy': "Copy",
   
   'content.loading': 'loading',
   
@@ -62,7 +63,9 @@ const en = {
   'flows.simulate.title': "Debug the flow",
 
   'flows.composer.title': 'Create new FLOW',
+  'flows.composer.copyTitle': 'Copy FLOW as',
   'flows.composer.createdMessage': 'Created FLOW: {name}',
+  'flows.composer.copiedMessage': 'Copied FLOW {name} as: {newName}',
   'flows.composer.errorsTitle': 'Failed to create FLOW',
   'flows.composer.assetName': 'Unique name for the FLOW',
 

--- a/src/core/intl/en.ts
+++ b/src/core/intl/en.ts
@@ -90,7 +90,9 @@ const en = {
   'services.simulate.title': "Debug the service",
   
   'services.composer.title': 'Create new SERVICE',
+  'services.composer.copyTitle': 'Copy SERVICE as',
   'services.composer.createdMessage': 'Created SERVICE: {name}',
+  'services.composer.copiedMessage': 'Copied SERVICE {name} as: {newName}',
   'services.composer.errorsTitle': 'Failed to create SERVICE',
   'services.composer.assetName': 'Unique name for the SERVICE',
 
@@ -109,7 +111,9 @@ const en = {
   'decisions.table.options': "Options",
 
   'decisions.composer.title': 'Create new DECISION',
+  'decisions.composer.copyTitle': 'Copy DECISION as',
   'decisions.composer.createdMessage': 'Created DECISION: {name}',
+  'decisions.composer.copiedMessage': 'Copied DECISION {name} as: {newName}',
   'decisions.composer.errorsTitle': 'Failed to create DECISION',
   'decisions.composer.assetName': 'Unique name for the DECISION',
 


### PR DESCRIPTION
 - Relates to the [issue](https://github.com/the-wrench-io/hdes-parent/issues/32) reported in hdes-parent repository
 - Copying of assets was implemented on backend, but not on frontend
 ### Users should now be able to copy assets in the following way: 
- After clicking on the copy button, dialog box appears prompting to enter a new name for the flow being copied
- By default the box will be pre-populated with the old asset's name + '_copy' (e.g. if the old name was task, the new would be task_copy)
- After optionally editing the name, and then clicking the copy button, a new asset will be created with the given name and old asset's information
- A Snackbar message will appear stating that the asset has been successfully copied
- The new copied asset will be opened in a new tab

https://user-images.githubusercontent.com/80248680/186639406-80411802-e07b-4c08-a6c5-62523828da7b.mp4
