### PR TITLE
Fix: Entering decimal values in decision tables

### DIFF
--- a/src/core/decision/editors/builders/TypeNumberBuilder.ts
+++ b/src/core/decision/editors/builders/TypeNumberBuilder.ts
@@ -42,7 +42,7 @@ function isValidNumber(value: string | null, type: API.TypeDef) {
     return false;
   }
   let isInteger = /^\d+$/.test(value);
-  let isDouble = ((value as any) % 1 !== 0); 
+  let isDouble = /^\d+\.\d*$/.test(value);
   if(type.valueType === 'INTEGER' || type.valueType === 'LONG') {
     return isInteger && !isDouble;
   } else if(type.valueType === 'DECIMAL') {
@@ -125,6 +125,7 @@ class NumberBuilder {
   }
   
   getValue() {
+    console.log('getValue', this._value);
     if(this._value) {
       let split = this._value.split(' ');
       if(split.length > 1) {


### PR DESCRIPTION
- Relates to the [issue](https://github.com/the-wrench-io/hdes-parent/issues/31) reported in hdes-parent repository
- Entering decimal values in decision tables was done with difficulties - entering a dot clears the input
### The issue has been identified to be with number validation
- DECIMAL type values are valid if they are either an Integer or a Double
- Validation for Double has been done by checking if the number has a remainder
- Due to this, entering a dot ('.') would break both validations and treat the input as invalid, therefore clearing it
- Now a RegExp is being used for validation and allows entering numbers such as (1, 1., 1.0, 1.11...)

https://user-images.githubusercontent.com/80248680/186676840-d46ecc0b-73af-4a51-b7bc-93191f775ed4.mp4

