### PR TITLE
Download CSV

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build"
   ],
   "dependencies": {
-    "@the-wrench-io/react-burger": "^1.0.31",
+    "@the-wrench-io/react-burger": "^1.0.36",
     "codemirror": "^5.40.0",
     "js-file-download": "^0.4.4",
     "moment": "^2.29.1",

--- a/src/core/debug/DebugView.tsx
+++ b/src/core/debug/DebugView.tsx
@@ -94,7 +94,10 @@ const DebugView: React.FC<{}> = ({ }) => {
 
   const downloadCsv = (delimiter: string, wrap: boolean) => {
     var content : string = debug?.debug?.bodyCsv ? debug?.debug?.bodyCsv : "";
-    if (content.endsWith("\r") || content.endsWith("\n") || content.endsWith("\r\n")) {
+    if (content.includes('\r')) {
+      content = content.replace(/\r/g, '');
+    }
+    if (content.endsWith("\n")) {
       content = content.substring(0, content.length - 1);
     }
     const lines = content.split('\n');

--- a/src/core/debug/DebugView.tsx
+++ b/src/core/debug/DebugView.tsx
@@ -86,6 +86,27 @@ const DebugView: React.FC<{}> = ({ }) => {
       .catch(error => actions.handleDebugUpdate({ inputType, csv, selected, json, error, debug: undefined }))
   }
 
+  const downloadCsv = () => {
+    var content : string = debug?.debug?.bodyCsv ? debug?.debug?.bodyCsv : "";
+    const lines = content.split('\n');
+    const outputHeaders = lines[0].split(',');
+    const outputLines = lines.slice(1, lines.length/2);
+    const inputHeaders = lines[lines.length/2].split(';');
+    const inputLines = lines.slice(lines.length/2+1, lines.length);
+    const finalHeaders = inputHeaders.concat(outputHeaders);
+    const finalLines = inputLines.map((inputLine, index) => {
+      const outputLine = outputLines[index];
+      return inputLine.replace(';',',').concat(',').concat(outputLine);
+    });
+    const finalContent = finalHeaders.join(',').concat('\n').concat(finalLines.join('\n'));
+    var blob = new Blob([finalContent], { type: 'text/csv' });
+    var url = window.URL.createObjectURL(blob);
+    var pom = document.createElement('a');
+    pom.href = url;
+    pom.setAttribute('download', 'results.csv');
+    pom.click();
+  }
+
   return (<Box sx={{ width: '100%', overflow: 'hidden', padding: 1 }}>
 
     <DebugDrawer selected={selected} open={option === "DRAWER"} onClose={() => setOption(undefined)} onSelect={setOption} />
@@ -106,6 +127,7 @@ const DebugView: React.FC<{}> = ({ }) => {
           <Burger.PrimaryButton disabled={selected ? false : true} label="debug.toolbar.openAsset" onClick={() => entity && nav.handleInTab({ article: entity })} sx={{ ml: 1 }} />
           <Burger.PrimaryButton label="debug.toolbar.options" onClick={() => setOption('DRAWER')} sx={{ ml: 1 }} />
           <Burger.PrimaryButton disabled={selected ? false : true} label="debug.toolbar.execute" onClick={() => handleExecute()} sx={{ ml: 1 }} />
+          {inputType === 'CSV' && debug?.debug?.bodyCsv ? <Burger.PrimaryButton disabled={selected ? false : true} label="debug.toolbar.download" onClick={() => downloadCsv()} sx={{ ml: 1 }} /> : null}
         </DebugHeader>
 
         <TableBody>

--- a/src/core/debug/DebugView.tsx
+++ b/src/core/debug/DebugView.tsx
@@ -210,14 +210,6 @@ const DebugView: React.FC<{}> = ({ }) => {
     return combinedHeaders.join(';').concat('\n').concat(combinedLines.join('\n'));
   }
 
-  const StyledRadio = styled(Radio)({
-    marginLeft: 10, 
-    color: 'rgb(80, 72, 229)', 
-    '&.Mui-checked': { 
-      color: 'rgb(80, 72, 229)' 
-    }
-  });
-
   let dialogChildren = (
     <>
       <p><b>{intl.formatMessage({id: 'debug.csv.download.delimiter'})}</b></p>
@@ -227,8 +219,8 @@ const DebugView: React.FC<{}> = ({ }) => {
         value={delimiter}
         onChange={(e) => setDelimiter(e.target.value)}
       >
-        <FormControlLabel value="comma" control={<StyledRadio />} label={intl.formatMessage({id: 'debug.csv.download.delimiter.comma'})} />
-        <FormControlLabel value="semicolon" control={<StyledRadio />} label={intl.formatMessage({id: 'debug.csv.download.delimiter.semicolon'})} />
+        <FormControlLabel value="comma" control={<Burger.RadioButton />} label={intl.formatMessage({id: 'debug.csv.download.delimiter.comma'})} />
+        <FormControlLabel value="semicolon" control={<Burger.RadioButton />} label={intl.formatMessage({id: 'debug.csv.download.delimiter.semicolon'})} />
       </RadioGroup>
       <p>{intl.formatMessage({id: 'debug.csv.download.options'})}</p>
       <Burger.Checkbox checked={wrap} onChange={() => setWrap(!wrap)} />

--- a/src/core/debug/DebugView.tsx
+++ b/src/core/debug/DebugView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, TableContainer, Table, TableBody } from '@mui/material';
+import { Box, TableContainer, Table, TableBody, RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import { styled } from '@mui/material/styles';
 
 import Burger from '@the-wrench-io/react-burger';
 import { Client, Composer } from '../context';
@@ -15,6 +16,7 @@ import { DebugHeader } from './DebugHeader';
 import { DebugInput } from './DebugInput';
 import { DebugOutput } from './outputs/DebugOutput';
 import { DebugOptionType } from './api';
+import { useIntl } from 'react-intl';
 
 
 const getData = (session: Composer.Session): {
@@ -44,6 +46,10 @@ const DebugView: React.FC<{}> = ({ }) => {
   const nav = Composer.useNav();
   const { ast, debug, entity, debugValues } = getData(session);
   const [option, setOption] = React.useState<DebugOptionType | undefined>();
+  const [dialogShow, setDialogShow] = React.useState(false);
+  const [delimiter, setDelimiter] = React.useState("semicolon");
+  const [wrap, setWrap] = React.useState(false);
+  const intl = useIntl();
 
   const selected = debug?.selected ? debug.selected : "";
   const json = debug?.json ? debug?.json : debugValues;
@@ -86,19 +92,26 @@ const DebugView: React.FC<{}> = ({ }) => {
       .catch(error => actions.handleDebugUpdate({ inputType, csv, selected, json, error, debug: undefined }))
   }
 
-  const downloadCsv = () => {
+  const downloadCsv = (delimiter: string, wrap: boolean) => {
     var content : string = debug?.debug?.bodyCsv ? debug?.debug?.bodyCsv : "";
+    if (content.endsWith("\r") || content.endsWith("\n") || content.endsWith("\r\n")) {
+      content = content.substring(0, content.length - 1);
+    }
     const lines = content.split('\n');
     const outputHeaders = lines[0].split(',');
     const outputLines = lines.slice(1, lines.length/2);
     const inputHeaders = lines[lines.length/2].split(';');
     const inputLines = lines.slice(lines.length/2+1, lines.length);
-    const finalHeaders = inputHeaders.concat(outputHeaders);
-    const finalLines = inputLines.map((inputLine, index) => {
-      const outputLine = outputLines[index];
-      return inputLine.replace(';',',').concat(',').concat(outputLine);
-    });
-    const finalContent = finalHeaders.join(',').concat('\n').concat(finalLines.join('\n'));
+    var finalContent = "";
+    if (!wrap) {
+      finalContent = delimiter === "comma" ? 
+        formatCsvForDownloadWithComma(outputHeaders, outputLines, inputHeaders, inputLines) : 
+        formatCsvForDownloadWithSemicolon(outputHeaders, outputLines, inputHeaders, inputLines);
+    } else {
+      finalContent = delimiter === "comma" ? 
+        wrapAndComma(outputHeaders, outputLines, inputHeaders, inputLines) : 
+        wrapAndSemicolon(outputHeaders, outputLines, inputHeaders, inputLines);
+    }
     var blob = new Blob([finalContent], { type: 'text/csv' });
     var url = window.URL.createObjectURL(blob);
     var pom = document.createElement('a');
@@ -106,6 +119,123 @@ const DebugView: React.FC<{}> = ({ }) => {
     pom.setAttribute('download', 'results.csv');
     pom.click();
   }
+
+  const formatCsvForDownloadWithSemicolon = (outputHeaders: string[], outputLines: string[], inputHeaders: string[], inputLines: string[]) => {
+    const finalHeaders = inputHeaders.concat(outputHeaders);
+    const finalLines = inputLines.map((inputLine, index) => {
+      const outputLine = outputLines[index].replace(/,/g, ';');
+      return inputLine.concat(';').concat(outputLine);
+    });
+    const finalContent = finalHeaders.join(';').concat('\n').concat(finalLines.join('\n'));
+    return finalContent;
+  }
+
+  const formatCsvForDownloadWithComma = (outputHeaders: string[], outputLines: string[], inputHeaders: string[], inputLines: string[]) => {
+    const finalHeaders = inputHeaders.concat(outputHeaders);
+    const finalLines = inputLines.map((inputLine, index) => {
+      const outputLine = outputLines[index];
+      return inputLine.replace(';',',').concat(',').concat(outputLine);
+    });
+    const finalContent = finalHeaders.join(',').concat('\n').concat(finalLines.join('\n'));
+    return finalContent;
+  }
+
+  const wrapAndComma = (outputHeaders: string[], outputLines: string[], inputHeaders: string[], inputLines: string[]) => {
+    const combinedHeaders = inputHeaders.concat(outputHeaders);
+    const combinedLines = inputLines.map((inputLine, index) => {
+      const outputLine = outputLines[index];
+      const outputValues = outputLine.split(',');
+      // handling cases where output contains a comma
+      for (let j = 0; j < outputValues.length; j++) {
+          const outputValue = outputValues[j];
+          if (outputValue.startsWith('"') ) {
+              for (let k = j+1; k < outputValues.length; k++) {
+                  const outputValue2 = outputValues[k];
+                  if (outputValue2.endsWith('"')) {
+                      outputValues[j] = outputValues.slice(j, k+1).join(',').slice(1, -1);
+                      outputValues.splice(j+1, k-j);
+                      break;
+                  }
+              }
+          }
+      }
+      // wrap output values
+      for (let j = 0; j < outputValues.length; j++) {
+          const outputValue = outputValues[j];
+          if (outputValue.includes(',')) {
+              outputValues[j] = '"' + outputValue + '"';
+          }
+      }
+      // wrap input values
+      const inputValues = inputLine.split(';');
+      for (let j = 0; j < inputValues.length; j++) {
+          const inputValue = inputValues[j];
+          if (inputValue.includes(',')) {
+              inputValues[j] = '"' + inputValue + '"';
+          }
+      }
+      return inputValues.concat(outputValues).join(',');
+    });
+    return combinedHeaders.join(',').concat('\n').concat(combinedLines.join('\n'));
+  }
+
+  const wrapAndSemicolon = (outputHeaders: string[], outputLines: string[], inputHeaders: string[], inputLines: string[]) => {
+    const combinedHeaders = inputHeaders.concat(outputHeaders);
+    const combinedLines = inputLines.map((inputLine, index) => {
+      const outputLine = outputLines[index];
+      const outputValues = outputLine.split(',');
+      // handling cases where output contains a comma
+      for (let j = 0; j < outputValues.length; j++) {
+        const outputValue = outputValues[j];
+        if (outputValue.startsWith('"') && !outputValue.includes(';') ) {
+            for (let k = j+1; k < outputValues.length; k++) {
+                const outputValue2 = outputValues[k];
+                if (outputValue2.endsWith('"')) {
+                    outputValues[j] = outputValues.slice(j, k+1).join(',').slice(1, -1);
+                    outputValues.splice(j+1, k-j);
+                    break;
+                }
+            }
+        }
+      // wrap output values
+      for (let l = 0; l < outputValues.length; l++) {
+       const outputValue = outputValues[l];
+       if (outputValue.includes(';') && !outputValue.startsWith('"')) {
+           outputValues[l] = '"' + outputValue + '"';
+       }
+      }
+      }
+      return inputLine.concat(';').concat(outputValues.join(';'));
+    });
+    return combinedHeaders.join(';').concat('\n').concat(combinedLines.join('\n'));
+  }
+
+  const StyledRadio = styled(Radio)({
+    marginLeft: 10, 
+    color: 'rgb(80, 72, 229)', 
+    '&.Mui-checked': { 
+      color: 'rgb(80, 72, 229)' 
+    }
+  });
+
+  let dialogChildren = (
+    <>
+      <p><b>{intl.formatMessage({id: 'debug.csv.download.delimiter'})}</b></p>
+      <RadioGroup
+        aria-labelledby="demo-controlled-radio-buttons-group"
+        name="controlled-radio-buttons-group"
+        value={delimiter}
+        onChange={(e) => setDelimiter(e.target.value)}
+      >
+        <FormControlLabel value="comma" control={<StyledRadio />} label={intl.formatMessage({id: 'debug.csv.download.delimiter.comma'})} />
+        <FormControlLabel value="semicolon" control={<StyledRadio />} label={intl.formatMessage({id: 'debug.csv.download.delimiter.semicolon'})} />
+      </RadioGroup>
+      <p>{intl.formatMessage({id: 'debug.csv.download.options'})}</p>
+      <Burger.Checkbox checked={wrap} onChange={() => setWrap(!wrap)} />
+      <label>{intl.formatMessage({ id: 'debug.csv.download.wrap' })}</label>
+    </>
+  );
+
 
   return (<Box sx={{ width: '100%', overflow: 'hidden', padding: 1 }}>
 
@@ -127,7 +257,7 @@ const DebugView: React.FC<{}> = ({ }) => {
           <Burger.PrimaryButton disabled={selected ? false : true} label="debug.toolbar.openAsset" onClick={() => entity && nav.handleInTab({ article: entity })} sx={{ ml: 1 }} />
           <Burger.PrimaryButton label="debug.toolbar.options" onClick={() => setOption('DRAWER')} sx={{ ml: 1 }} />
           <Burger.PrimaryButton disabled={selected ? false : true} label="debug.toolbar.execute" onClick={() => handleExecute()} sx={{ ml: 1 }} />
-          {inputType === 'CSV' && debug?.debug?.bodyCsv ? <Burger.PrimaryButton disabled={selected ? false : true} label="debug.toolbar.download" onClick={() => downloadCsv()} sx={{ ml: 1 }} /> : null}
+          {inputType === 'CSV' && debug?.debug?.bodyCsv ? <Burger.PrimaryButton disabled={selected ? false : true} label="debug.toolbar.download" onClick={() => setDialogShow(true)} sx={{ ml: 1 }} /> : null}
         </DebugHeader>
 
         <TableBody>
@@ -137,6 +267,19 @@ const DebugView: React.FC<{}> = ({ }) => {
         </TableBody>
       </Table>
     </TableContainer>
+
+    { dialogShow && <Burger.Dialog open={true}
+      onClose={() => setDialogShow(false)}
+      backgroundColor="uiElements.main"
+      children={dialogChildren}
+      title='debug.csv.download'
+      submit={{
+        title: "buttons.download",
+        disabled: false,
+        onClick: () => downloadCsv(delimiter, wrap)
+      }}
+    /> }
+
   </Box >);
 }
 

--- a/src/core/debug/outputs/DebugOutputCsv.tsx
+++ b/src/core/debug/outputs/DebugOutputCsv.tsx
@@ -7,6 +7,9 @@ const mapCsvRows = (debug: string): Client.CsvRow[] => {
         return [];
     }
     const result: Client.CsvRow[] = [];
+    if (debug.endsWith("\r") || debug.endsWith("\n") || debug.endsWith("") || debug.endsWith(" ")) {
+        debug = debug.substring(0, debug.length - 1);
+    }
     const lines = debug.split('\n');
     const outputHeaders = lines[0].split(',');
     const outputLines = lines.slice(1, lines.length/2);

--- a/src/core/debug/outputs/DebugOutputCsv.tsx
+++ b/src/core/debug/outputs/DebugOutputCsv.tsx
@@ -7,7 +7,12 @@ const mapCsvRows = (debug: string): Client.CsvRow[] => {
         return [];
     }
     const result: Client.CsvRow[] = [];
-    if (debug.endsWith("\r") || debug.endsWith("\n") || debug.endsWith("\r\n")) {
+    // remove carriage returns
+    if (debug.includes('\r')) {
+        debug = debug.replace(/\r/g, '');
+    }
+    // remove empty row at the end (occurs with file import)
+    if (debug.endsWith("\n")) {
         debug = debug.substring(0, debug.length - 1);
     }
     const lines = debug.split('\n');

--- a/src/core/debug/outputs/DebugOutputCsv.tsx
+++ b/src/core/debug/outputs/DebugOutputCsv.tsx
@@ -41,7 +41,7 @@ const mapCsvRows = (debug: string): Client.CsvRow[] => {
 const DebugOutputCsv: React.FC<{ debug: string }> = ({ debug }) => {
     const csvRows = mapCsvRows(debug);
     return (<>
-      {csvRows.map((csvRow: Client.CsvRow) => <DebugOutputCsvRow csvRow={csvRow} index={csvRow.id}/>)}
+      {csvRows.map((csvRow: Client.CsvRow) => <DebugOutputCsvRow key={csvRow.id} csvRow={csvRow} index={csvRow.id}/>)}
     </>);
 }
   

--- a/src/core/debug/outputs/DebugOutputCsv.tsx
+++ b/src/core/debug/outputs/DebugOutputCsv.tsx
@@ -41,7 +41,7 @@ const mapCsvRows = (debug: string): Client.CsvRow[] => {
                 outputValues[j] = outputValue.slice(1, -1);
             }
         }
-        const rowId = outputLine[0];
+        const rowId = outputValues[0];
         const csvRow: Client.CsvRow = { id: rowId, inputs: [], outputs: [] };
         for (let j = 0; j < inputValues.length; j++) {
             csvRow.inputs.push({

--- a/src/core/debug/outputs/DebugOutputCsv.tsx
+++ b/src/core/debug/outputs/DebugOutputCsv.tsx
@@ -20,6 +20,27 @@ const mapCsvRows = (debug: string): Client.CsvRow[] => {
         const outputLine = outputLines[i];
         const inputValues = inputLine.split(';');
         const outputValues = outputLine.split(',');
+        // handling cases where output contains a comma
+        for (let j = 0; j < outputValues.length; j++) {
+            const outputValue = outputValues[j];
+            if (outputValue.startsWith('"') && !outputValue.includes(';')) {
+                for (let k = j+1; k < outputValues.length; k++) {
+                    const outputValue2 = outputValues[k];
+                    if (outputValue2.endsWith('"')) {
+                        outputValues[j] = outputValues.slice(j, k+1).join(',').slice(1, -1);
+                        outputValues.splice(j+1, k-j);
+                        break;
+                    }
+                }
+            }
+        }
+        // handling cases where output contains a semicolon
+        for (let j = 0; j < outputValues.length; j++) {
+            const outputValue = outputValues[j];
+            if (outputValue.startsWith('"') && outputValue.includes(';')) {
+                outputValues[j] = outputValue.slice(1, -1);
+            }
+        }
         const rowId = outputLine[0];
         const csvRow: Client.CsvRow = { id: rowId, inputs: [], outputs: [] };
         for (let j = 0; j < inputValues.length; j++) {

--- a/src/core/debug/outputs/DebugOutputCsv.tsx
+++ b/src/core/debug/outputs/DebugOutputCsv.tsx
@@ -7,7 +7,7 @@ const mapCsvRows = (debug: string): Client.CsvRow[] => {
         return [];
     }
     const result: Client.CsvRow[] = [];
-    if (debug.endsWith("\r") || debug.endsWith("\n") || debug.endsWith("") || debug.endsWith(" ")) {
+    if (debug.endsWith("\r") || debug.endsWith("\n") || debug.endsWith("\r\n")) {
         debug = debug.substring(0, debug.length - 1);
     }
     const lines = debug.split('\n');

--- a/src/core/intl/en.ts
+++ b/src/core/intl/en.ts
@@ -230,6 +230,7 @@ const en = {
   'debug.toolbar.execute': "Execute",
   'debug.toolbar.noAsset': "Select asset from options",
   'debug.toolbar.openAsset': "Open",
+  'debug.toolbar.download': "Download results as CSV",
     
   'debug.input.noAsset': "There is no ASSET selected",
   'debug.input.form': "Debug using FORM",
@@ -238,8 +239,8 @@ const en = {
   'debug.input.jsonTitle': "Define JSON input",
   'debug.input.csvUpload': "Debug using CSV",
   'debug.input.csvFile': "Upload CSV FILE",
-  'debug.input.csvFileTitle': "Upload CSV format(;) file",
-  'debug.input.csvFileOrText': "Or paste CSV contents, format(;)",
+  'debug.input.csvFileTitle': "Upload CSV file - semicolon-delimited (;)",
+  'debug.input.csvFileOrText': "Or paste CSV contents - semicolon-delimited (;)",
   'debug.inputs.fieldName': "Field Name",
   'debug.inputs.fieldValue': "Field Value",
   

--- a/src/core/intl/en.ts
+++ b/src/core/intl/en.ts
@@ -4,6 +4,7 @@ const en = {
   'buttons.delete': "Delete",
   'button.cancel': "Cancel",
   'buttons.copy': "Copy",
+  'buttons.download': "Download",
   
   'content.loading': 'loading',
   
@@ -268,6 +269,12 @@ const en = {
   'debug.asset.execute.outputs.flow.step': "Step name: {name}, status: {status}",
 
   'debug.csv.row': "Data row: {row}",
+  'debug.csv.download': "Download results as CSV",
+  'debug.csv.download.delimiter': "Choose a delimiter for the CSV file",
+  'debug.csv.download.delimiter.semicolon': "Semicolon (;)",
+  'debug.csv.download.delimiter.comma': "Comma (,)",
+  'debug.csv.download.options': "Export options",
+  'debug.csv.download.wrap': "Wrap cells containing delimiters with quotes",
 
 
 };


### PR DESCRIPTION
### Results of multirow CSV debugging can now be downloaded as a CSV file
- added download button
- button only appears if `bodyCsv` exists, i.e. after multirow CSV debugging has been completed
- dialog opens on button click where user can select a delimiter (',' or ';') and choose whether to wrap values
- file `results.csv` downloaded on click
- added minor fixes for handling delimiters within cells