### PR TITLE
Improve the flow graph

### DIFF
--- a/src/core/flow/FlowEdit.tsx
+++ b/src/core/flow/FlowEdit.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Box } from '@mui/material';
+import { Box, Divider, IconButton, Tooltip } from '@mui/material';
 
 import CodeEditor, { HintProps } from '../../code-editor';
 import { Client, Composer } from '../context';
 import Graph from './graph';
 import { AutocompleteVisitor, FlowAstAutocomplete, AutocompleteTask } from './autocomplete';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { FormattedMessage } from 'react-intl';
 
 
 type GuidedHint = (cm: CodeMirror.Editor, data: CodeMirror.Hints, cur: CodeMirror.Hint) => void;
@@ -13,8 +15,7 @@ const SticyGraph: React.FC<{ flow: Client.AstFlow, site: Client.Site }> = ({ flo
   
   const nav = Composer.useNav();
 
-  
-  return (<Box sx={{ top: "64px", right: "30px", position: "absolute", zIndex: "100" }}>
+  return (
     <Graph flow={flow} site={site}
       onClick={() => console.log("single")}
       onDoubleClick={(id) => {
@@ -29,8 +30,9 @@ const SticyGraph: React.FC<{ flow: Client.AstFlow, site: Client.Site }> = ({ flo
         if(article) {
           nav.handleInTab({ article })
         }
-      }} />
-  </Box>);
+      }} 
+    />
+  );
 }
 
 
@@ -38,10 +40,11 @@ const FlowEdit: React.FC<{ flow: Client.Entity<Client.AstFlow> }> = ({ flow }) =
   const { session, actions, service } = Composer.useComposer();
   const { site } = session;
   const update = session.pages[flow.id];
-  const src = flow.ast?.src.value;  
+  const src = flow.ast?.src.value;
   
   const [ast, setAst] = React.useState<Client.AstFlow | undefined>(flow.ast);
   const [guided, setGuided] = React.useState<{ cm: CodeMirror.Editor, data: CodeMirror.Hints, cur: CodeMirror.Hint, guided: FlowAstAutocomplete }>();
+  const [showGraph, setShowGraph] = React.useState<boolean>(false);
   const commands = React.useMemo(() => update ? update.value : flow.source.commands, [flow, update]);
   const flowId = flow.id;
   
@@ -49,35 +52,41 @@ const FlowEdit: React.FC<{ flow: Client.Entity<Client.AstFlow> }> = ({ flow }) =
     service.ast(flowId, commands).then(data => setAst(data.ast));
   }, [commands, flowId, service])
 
-
-  return (<Box height="100%">
+  return (<Box sx={{ height: 1, display: 'flex' }}>
     {guided ? <AutocompleteTask onClose={() => setGuided(undefined)} flow={flow} {...guided} /> : undefined}
-    {ast ? <SticyGraph flow={ast} site={site} /> : undefined}
-        
-    <CodeEditor id={flow.id} mode="yaml" src={src ? src : "#--failed-to-parse"}
-      onChange={(value) => actions.handlePageUpdate(flow.id, [{ type: "SET_BODY", value }])}
-      hint={(hintProps: HintProps) => {
-        const { pos, emptyLine } = hintProps;
-        const ac = ast ? new AutocompleteVisitor(ast, site, pos).visit() : [];
-        const result: CodeMirror.Hints = { from: { line: pos.line, ch: 0 }, to: pos, list: [] };
-        for (const src of ac) {
-          const hint: GuidedHint | undefined = src.guided ? (cm, data, cur) => setGuided({ cm, data, cur, guided: src }) : undefined;
-          const from = src.append && !emptyLine ? { line: pos.line, ch: pos.ch } : undefined;
-          const newText: string[] = [];
-          if(src.append && !emptyLine) {
-            newText.push("");
-          } 
-          newText.push(...src.value);
-          result.list.push({ text: newText.join("\r\n"), displayText: src.id, from, hint })
-        }
-        return result;
-      }}
-      lint={() => {
-        if (!ast || ast.messages.length === 0) {
-          return [];
-        }
-        return ast?.messages.map(m => ({ type: m.type, line: m.line, value: m.value }));
-      }} />
+    <Tooltip title={<FormattedMessage id={showGraph ? 'flows.graph.hide' : 'flows.graph.show'} />} placement="left">
+      <IconButton sx={{ top: '74px', right: '10px', position: 'absolute', zIndex: 10 }} onClick={() => setShowGraph(!showGraph)}>
+        {showGraph ? <VisibilityOff /> : <Visibility />}
+      </IconButton>
+    </Tooltip>
+    <Box sx={{ width: showGraph ? 0.7 : 1 }}>
+      <CodeEditor id={flow.id} mode="yaml" src={src ? src : "#--failed-to-parse"}
+        onChange={(value) => actions.handlePageUpdate(flow.id, [{ type: "SET_BODY", value }])}
+        hint={(hintProps: HintProps) => {
+          const { pos, emptyLine } = hintProps;
+          const ac = ast ? new AutocompleteVisitor(ast, site, pos).visit() : [];
+          const result: CodeMirror.Hints = { from: { line: pos.line, ch: 0 }, to: pos, list: [] };
+          for (const src of ac) {
+            const hint: GuidedHint | undefined = src.guided ? (cm, data, cur) => setGuided({ cm, data, cur, guided: src }) : undefined;
+            const from = src.append && !emptyLine ? { line: pos.line, ch: pos.ch } : undefined;
+            const newText: string[] = [];
+            if(src.append && !emptyLine) {
+              newText.push("");
+            } 
+            newText.push(...src.value);
+            result.list.push({ text: newText.join("\r\n"), displayText: src.id, from, hint })
+          }
+          return result;
+        }}
+        lint={() => {
+          if (!ast || ast.messages.length === 0) {
+            return [];
+          }
+          return ast?.messages.map(m => ({ type: m.type, line: m.line, value: m.value }));
+        }} />
+      </Box>
+      <Divider orientation='vertical' />
+      {(ast && showGraph) ? <SticyGraph flow={ast} site={site} /> : undefined}
   </Box>);
 }
 

--- a/src/core/flow/graph/GraphAPI.ts
+++ b/src/core/flow/graph/GraphAPI.ts
@@ -130,7 +130,7 @@ class ModelVisitor {
       this.visitThen(step.then, { parent: node, index: props.index });
     } else if (group === "service") {
       if(ref) {
-        //this.visitServiceAssoc(ref, { parent: node, index: props.index });
+        this.visitServiceAssoc(ref, { parent: node, index: props.index });
       }
       this.visitThen(step.then, { parent: node, index: props.index });
     }
@@ -170,6 +170,8 @@ class ModelVisitor {
       parents.push(parent.id);
       const group: ModelType = caseInTask.refType === "FLOW" ? "flow" : 'decisionTable';
       const id = caseInTask.ref + "/" + parent.id  + "/" + (caseInTask.id ? caseInTask.id : caseInTask.ref);
+      const offsetX = assocs.length === 1 ? (150 + id.length) : 100;
+      const offsetY = assocs.length === 1 ? 0 : 50;
       const node: Vis.Node = {
         id: id,
         parents: parents,
@@ -178,7 +180,7 @@ class ModelVisitor {
         group: group,
         color: this.visitColor(group),
         shape: this.visitShape(group),
-        x: caseX, y: parent.y,
+        x: caseX + offsetX, y: parent.y + offsetY,
         body: { ref },
         widthConstraint: this._constraints.width
       }
@@ -199,15 +201,7 @@ class ModelVisitor {
         this._nodes.push(...nested.nodes)
         this._visited.push(...nested.visited);
         
-        //this.visitStep(flow., { parent: node });
       }
-      /*
-      this.visitThen(caseInTask.then, {
-        parent: props.parent,
-        index: props.index ? props.index : 0 + caseX
-      });
-      */
-      
     }
   }
   

--- a/src/core/flow/graph/GraphAPI.ts
+++ b/src/core/flow/graph/GraphAPI.ts
@@ -144,7 +144,13 @@ class ModelVisitor {
     }  
     
     const {parent} = props;
-    const assocs = entity.associations.filter(assoc => assoc.owner);
+    const allAssocs = entity.associations.filter(assoc => assoc.owner);
+
+    // in case multiple refs are defined, but only one is used at a time, filter it out
+    const refName: string = parent.body?.step?.children?.service?.inputs?.refName?.value;
+    const usedAssoc = allAssocs.filter(assoc => assoc.ref === refName);
+    
+    const assocs = refName ? usedAssoc : allAssocs;
     
     let index = 0
     let evenX = 0

--- a/src/core/intl/en.ts
+++ b/src/core/intl/en.ts
@@ -92,6 +92,9 @@ const en = {
   'flows.autocomplete.task.snackbar.created': "Created new {type}: {name}",
   'flows.autocomplete.task.snackbar.creating': "Creating new {type}: {name}",
 
+  'flows.graph.show': 'Show flow graph',
+  'flows.graph.hide': 'Hide flow graph',
+  
 
   'services.edit.title': "Edit service",
   'services.copyas.title': "Copy service as",


### PR DESCRIPTION
 - flow graph now shows service refs
 - in case multiple refs are defined for a service, but only one ref is used within a step, it can be parametrized through `refName` input and then the graph will only show that ref
 - there is a show/hide button added in the top right corner of the flow editor, which toggles whether the graph is displayed in its own container on the side
 
![image](https://github.com/the-wrench-io/hdes-composer/assets/80248680/4e468a3a-10d3-4cbb-a319-ef1f32184f25)
![image](https://github.com/the-wrench-io/hdes-composer/assets/80248680/489b1c44-8219-4f95-a6e1-94dff2ca3c41)
